### PR TITLE
Fixes clojure.lang.Symbol cannot be cast to clojure.lang.Associative

### DIFF
--- a/src/leiningen/new/hoplon.clj
+++ b/src/leiningen/new/hoplon.clj
@@ -8,7 +8,7 @@
     tailrecursion/hoplon])
 
 (defn latest-deps-strs [deps]
-  (mapv (partial latest-version-string! {:snapshots? false}) deps))
+  (mapv #(latest-version-string! % {:snapshots? false}) deps))
 
 (defn hoplon
   "Create new Hoplon project."


### PR DESCRIPTION
Fixes same error found in the `hoplon-castra` template at https://github.com/tailrecursion/hoplon-castra-template/pull/1.