### PR TITLE
Pin dependecies versions

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,7 @@
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "3.2.4")
+(def +version+ "3.2.5")
 
 (bootlaces! +version+)
 

--- a/src/leiningen/new/hoplon.clj
+++ b/src/leiningen/new/hoplon.clj
@@ -6,7 +6,7 @@
   "Create new Hoplon project."
   [name]
   (let [boot-cljs-v "1.7.228-2"
-        boot-core-v "2.6.0"
+        boot-core-v "2.7.1"
         boot-jetty-v "0.1.3"
         boot-reload-v "0.4.13"
         clojure-v "1.8.0"

--- a/src/leiningen/new/hoplon.clj
+++ b/src/leiningen/new/hoplon.clj
@@ -1,36 +1,21 @@
 (ns leiningen.new.hoplon
-  (:require [leiningen.new.templates :as t]
-            [ancient-clj.core        :refer [latest-version-string!]]))
-
-(def deps
-  '[boot/core
-    adzerk/boot-cljs
-    adzerk/boot-reload
-    org.clojure/clojurescript
-    hoplon/boot-hoplon
-    hoplon/hoplon
-    tailrecursion/boot-jetty])
-
-(defn latest-deps-strs [deps]
-  (mapv #(latest-version-string! % {:snapshots? false}) deps))
+  (:require
+    [leiningen.new.templates :as t]))
 
 (defn hoplon
   "Create new Hoplon project."
   [name]
-  (let [[boot-core-v
-         boot-cljs-v
-         boot-reload-v
-         clojurescript-v
-         boot-hoplon-v
-         hoplon-v
-         boot-jetty-v] (latest-deps-strs deps)
+  (let [boot-cljs-v "1.7.228-2"
+        boot-core-v "2.6.0"
+        boot-jetty-v "0.1.3"
+        boot-reload-v "0.4.13"
         clojure-v "1.8.0"
+        clojurescript-v "1.9.293"
+        hoplon-v "6.0.0-alpha17"
         render  (t/renderer "hoplon")
-        main-ns (t/multi-segment (t/sanitize-ns name))
         data    {:raw-name         name
                  :boot-cljs-v      boot-cljs-v
                  :boot-core-v      boot-core-v
-                 :boot-hoplon-v    boot-hoplon-v
                  :boot-jetty-v     boot-jetty-v
                  :boot-reload-v    boot-reload-v
                  :clojure-v        clojure-v

--- a/src/leiningen/new/hoplon/boot.properties
+++ b/src/leiningen/new/hoplon/boot.properties
@@ -1,4 +1,3 @@
 #https://github.com/boot-clj/boot
 BOOT_CLOJURE_VERSION={{clojure-v}}
 BOOT_VERSION={{boot-core-v}}
-BOOT_EMIT_TARGET=no

--- a/src/leiningen/new/hoplon/build.boot
+++ b/src/leiningen/new/hoplon/build.boot
@@ -1,7 +1,6 @@
 (set-env!
   :dependencies '[[adzerk/boot-cljs          "{{boot-cljs-v}}"]
                   [adzerk/boot-reload        "{{boot-reload-v}}"]
-                  [hoplon/boot-hoplon        "{{boot-hoplon-v}}"]
                   [hoplon/hoplon             "{{hoplon-v}}"]
                   [org.clojure/clojure       "{{clojure-v}}"]
                   [org.clojure/clojurescript "{{clojurescript-v}}"]

--- a/src/leiningen/new/hoplon/index.cljs.hl
+++ b/src/leiningen/new/hoplon/index.cljs.hl
@@ -2,6 +2,6 @@
 
 (html
   (head
-    (link :href "app.css" :rel "stylesheet"))
+    (link :href "app.css" :rel "stylesheet" :type "text/css"))
   (body
     (h1 "Hello, Hoplon!")))


### PR DESCRIPTION
This uses boot-reload `0.4.12` as I had errors running `0.4.13` https://github.com/adzerk-oss/boot-reload/issues/101
Also removes `boot-hoplon` as it is not necessary anymore.